### PR TITLE
Fixed compiler error on clang

### DIFF
--- a/src/widgets/tabbedarea.cpp
+++ b/src/widgets/tabbedarea.cpp
@@ -323,7 +323,7 @@ namespace gcn
         }
         
         // Draw the widget from a select tab.
-        std::vector<std::pair<Tab*, Widget*>>::iterator iter;
+        std::vector<std::pair<Tab*, Widget*> >::iterator iter;
         for (iter = mTabs.begin(); iter != mTabs.end(); iter++)
         {
             iter->first->_draw(graphics);


### PR DESCRIPTION
Otherwise when you use Clang, you will get an error like this
```
guichan/src/widgets/tabbedarea.cpp:326:44: error: a space
      is required between consecutive right angle brackets (use '> >')
        std::vector<std::pair<Tab*, Widget*>>::iterator iter;
```